### PR TITLE
fix pk may contains default null columns

### DIFF
--- a/sqlgen/db_generator.go
+++ b/sqlgen/db_generator.go
@@ -76,6 +76,9 @@ func GenNewIndex(id int, tbl *Table, w *Weight) *Index {
 		chosenCol := totalCols[chosenIdx]
 		totalCols[0], totalCols[chosenIdx] = totalCols[chosenIdx], totalCols[0]
 		totalCols = totalCols[1:]
+		if idx.Tp == IndexTypePrimary && chosenCol.defaultVal == "null" {
+			continue
+		}
 
 		idx.Columns = append(idx.Columns, chosenCol)
 		prefixLen := 0

--- a/sqlgen/db_mutator.go
+++ b/sqlgen/db_mutator.go
@@ -140,17 +140,6 @@ func (i *Index) AppendColumnIfNotExists(cols ...*Column) {
 	}
 }
 
-func (i *Index) RemoveColIf(filter func(c *Column) bool) {
-	newCols := make([]*Column, 0, len(i.Columns))
-	for _, c := range i.Columns {
-		if !filter(c) {
-			newCols = append(newCols, c)
-		}
-	}
-
-	i.Columns = newCols
-}
-
 func (p *Prepare) AppendColumns(cols ...*Column) {
 	for _, c := range cols {
 		p.Args = append(p.Args, func() string {

--- a/sqlgen/db_mutator.go
+++ b/sqlgen/db_mutator.go
@@ -140,6 +140,17 @@ func (i *Index) AppendColumnIfNotExists(cols ...*Column) {
 	}
 }
 
+func (i *Index) RemoveColIf(filter func(c *Column) bool) {
+	newCols := make([]*Column, 0, len(i.Columns))
+	for _, c := range i.Columns {
+		if !filter(c) {
+			newCols = append(newCols, c)
+		}
+	}
+
+	i.Columns = newCols
+}
+
 func (p *Prepare) AppendColumns(cols ...*Column) {
 	for _, c := range cols {
 		p.Args = append(p.Args, func() string {

--- a/sqlgen/db_retriever.go
+++ b/sqlgen/db_retriever.go
@@ -45,9 +45,9 @@ func (t *Table) GetRandColumn() *Column {
 	return t.Columns[rand.Intn(len(t.Columns))]
 }
 
-func (t *Table) GetRandColumnForPartition() *Column {
+func (t *Table) GetRandColumnForPartition(allowDefaultNull bool) *Column {
 	cols := t.FilterColumns(func(column *Column) bool {
-		return column.Tp.IsPartitionType()
+		return column.Tp.IsPartitionType() && (allowDefaultNull || column.defaultVal != "null")
 	})
 	if len(cols) == 0 {
 		return nil

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -173,6 +173,9 @@ func NewGenerator(state *State) func() string {
 		colDefs = NewFn("colDefs", func() Fn {
 			colDef = NewFn("colDef", func() Fn {
 				col := GenNewColumn(state.AllocGlobalID(ScopeKeyColumnUniqID), w)
+				if len(tbl.Columns) == 0 && col.defaultVal == "null" {
+					col.defaultVal = ""
+				}
 				tbl.AppendColumn(col)
 				return And(Str(col.Name), Str(PrintColumnType(col)))
 			})

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -200,6 +200,9 @@ func NewGenerator(state *State) func() string {
 				var clusteredKeyword string
 				if idx.Tp == IndexTypePrimary {
 					clusteredKeyword = "clustered"
+					idx.RemoveColIf(func(c *Column) bool {
+						return !c.isNotNull
+					})
 				}
 				return And(
 					Str(PrintIndexType(idx)),

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -193,14 +193,6 @@ func NewGenerator(state *State) func() string {
 						// all partitioned Columns should be contained in every unique/primary index.
 						c := partitionedCol.ToColumn()
 						Assert(c != nil)
-						if idx.Tp == IndexTypePrimary {
-							if c.defaultVal == "null" {
-								return Empty()
-							}
-							idx.RemoveColIf(func(col *Column) bool {
-								return col.defaultVal == "null"
-							})
-						}
 						idx.AppendColumnIfNotExists(c)
 					}
 				}
@@ -222,7 +214,7 @@ func NewGenerator(state *State) func() string {
 		})
 
 		partitionDef = NewFn("partitionDef", func() Fn {
-			partitionedCol := tbl.GetRandColumnForPartition()
+			partitionedCol := tbl.GetRandColumnForPartition(tbl.containsPK)
 			if partitionedCol == nil {
 				return Empty()
 			}


### PR DESCRIPTION
all part of the primary key must be `NOT NULL` and should contain all partition columns, so that if the table has a primary key, the partition column cannot be default null.