### PR TITLE
support generating DML_DEL using PK/no-PK by probability

### DIFF
--- a/sqlgen/db_config.go
+++ b/sqlgen/db_config.go
@@ -42,6 +42,10 @@ type Weight struct {
 	Query_DML                   int
 	Query_Select                int
 	Query_DML_DEL               int
+	Query_DML_DEL_INDEX			int
+	Query_DML_DEL_COMMON        int
+	Query_DML_DEL_INDEX_PK      int
+	Query_DML_DEL_INDEX_COMMON  int
 	Query_DML_INSERT            int
 	Query_DML_INSERT_ON_DUP     int
 	Query_DML_Can_Be_Replace    bool
@@ -88,6 +92,10 @@ var DefaultWeight = Weight{
 	Query_DML:                   20,
 	Query_Select:                1,
 	Query_DML_DEL:               1,
+	Query_DML_DEL_INDEX:         0,
+	Query_DML_DEL_COMMON:		 1,
+	Query_DML_DEL_INDEX_PK:      1,
+	Query_DML_DEL_INDEX_COMMON:  1,
 	Query_DML_UPDATE:            1,
 	Query_DML_INSERT:            1,
 	Query_DML_INSERT_ON_DUP:     4,

--- a/sqlgen/db_config.go
+++ b/sqlgen/db_config.go
@@ -42,7 +42,7 @@ type Weight struct {
 	Query_DML                   int
 	Query_Select                int
 	Query_DML_DEL               int
-	Query_DML_DEL_INDEX			int
+	Query_DML_DEL_INDEX         int
 	Query_DML_DEL_COMMON        int
 	Query_DML_DEL_INDEX_PK      int
 	Query_DML_DEL_INDEX_COMMON  int
@@ -93,7 +93,7 @@ var DefaultWeight = Weight{
 	Query_Select:                1,
 	Query_DML_DEL:               1,
 	Query_DML_DEL_INDEX:         0,
-	Query_DML_DEL_COMMON:		 1,
+	Query_DML_DEL_COMMON:        1,
 	Query_DML_DEL_INDEX_PK:      1,
 	Query_DML_DEL_INDEX_COMMON:  1,
 	Query_DML_UPDATE:            1,

--- a/sqlgen/db_retriever.go
+++ b/sqlgen/db_retriever.go
@@ -45,6 +45,36 @@ func (t *Table) GetRandColumn() *Column {
 	return t.Columns[rand.Intn(len(t.Columns))]
 }
 
+// GetRandIndexFirstColumnWithWeight returns a random index's first columns.
+// It will choose PK according to the probability of pkW / (pkW + npkW).
+// If there is no index, return GetRandColumn().
+func (t *Table) GetRandIndexFirstColumnWithWeight(pkW, npkW int) *Column {
+	if len(t.Indices) == 0 {
+		return t.GetRandColumn()
+	}
+	var pk *Index
+	npks := make([]*Index, 0, len(t.Indices))
+	for _, idx := range t.Indices {
+		if idx.Tp == IndexTypePrimary {
+			pk = idx
+		} else {
+			npks = append(npks, idx)
+		}
+	}
+
+	if rand.Intn(pkW + npkW) < pkW {
+		if pk == nil {
+			return t.GetRandColumn()
+		}
+		return pk.Columns[0]
+	} else {
+		if len(npks) == 0 {
+			return t.GetRandColumn()
+		}
+		return npks[rand.Intn(len(npks))].Columns[0]
+	}
+}
+
 // GetRandIndexPrefixColumn returns a random index's random prefix columns.
 func (t *Table) GetRandIndexPrefixColumn() []*Column {
 	idx := t.Indices[rand.Intn(len(t.Indices))]

--- a/sqlgen/db_retriever.go
+++ b/sqlgen/db_retriever.go
@@ -62,7 +62,7 @@ func (t *Table) GetRandIndexFirstColumnWithWeight(pkW, npkW int) *Column {
 		}
 	}
 
-	if rand.Intn(pkW + npkW) < pkW {
+	if rand.Intn(pkW+npkW) < pkW {
 		if pk == nil {
 			return t.GetRandColumn()
 		}

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -569,7 +569,12 @@ func newGenerator(state *State) func() string {
 
 	commonDelete = NewFn("commonDelete", func() Fn {
 		tbl := state.GetRandTable()
-		col := tbl.GetRandColumn()
+		var col *Column
+		if rand.Intn(w.Query_DML_DEL_COMMON + w.Query_DML_DEL_INDEX) < w.Query_DML_DEL_COMMON {
+			col = tbl.GetRandColumn()
+		} else {
+			col = tbl.GetRandIndexFirstColumnWithWeight(w.Query_DML_DEL_INDEX_COMMON, w.Query_DML_DEL_INDEX_COMMON)
+		}
 		state.Store(ScopeKeyCurrentTable, NewScopeObj(tbl))
 
 		multipleRowVal = NewFn("multipleRowVal", func() Fn {

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -570,7 +570,7 @@ func newGenerator(state *State) func() string {
 	commonDelete = NewFn("commonDelete", func() Fn {
 		tbl := state.GetRandTable()
 		var col *Column
-		if rand.Intn(w.Query_DML_DEL_COMMON + w.Query_DML_DEL_INDEX) < w.Query_DML_DEL_COMMON {
+		if rand.Intn(w.Query_DML_DEL_COMMON+w.Query_DML_DEL_INDEX) < w.Query_DML_DEL_COMMON {
 			col = tbl.GetRandColumn()
 		} else {
 			col = tbl.GetRandIndexFirstColumnWithWeight(w.Query_DML_DEL_INDEX_COMMON, w.Query_DML_DEL_INDEX_COMMON)


### PR DESCRIPTION
Support generating DML_DEL using PK/no-PK by probability

I add 4 new `Weight` configs:

|config|type|default|
|------|----|-------|
|Query_DML_DEL_INDEX|int|0
|Query_DML_DEL_COMMON|int|1
|Query_DML_DEL_INDEX_PK|int|1
|Query_DML_DEL_INDEX_COMMON|int|1

Usage:
- `Query_DML_DEL_INDEX : Query_DML_DEL_COMMON` decides whether to generate DML_DEL using index.
- `Query_DML_DEL_INDEX_PK : Query_DML_DEL_INDEX_COMMON` decides to generate DML_DEL using PK or non-PK.