### PR TITLE
sqlgen: add switch to turn off clustered hint

### DIFF
--- a/sqlgen/db_config.go
+++ b/sqlgen/db_config.go
@@ -31,6 +31,7 @@ type ControlOption struct {
 
 type Weight struct {
 	CreateTable                 int
+	CreateTable_WithClusterHint bool
 	CreateTable_MoreCol         int
 	CreateTable_WithoutLike     int
 	CreateTable_Partition_Type  string
@@ -81,6 +82,7 @@ func DefaultControlOption() *ControlOption {
 
 var DefaultWeight = Weight{
 	CreateTable:                 13,
+	CreateTable_WithClusterHint: true,
 	CreateTable_MoreCol:         2,
 	CreateTable_IndexMoreCol:    2,
 	CreateTable_MustPrefixIndex: false,

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -206,15 +206,18 @@ func newGenerator(state *State) func() string {
 				if idx.Tp == IndexTypePrimary {
 					clusteredKeyword = "/*T![clustered_index] clustered */"
 				}
-				return And(
+				fns := []Fn{
 					Str(PrintIndexType(idx)),
 					Str("key"),
 					Str(idx.Name),
 					Str("("),
 					Str(PrintIndexColumnNames(idx)),
 					Str(")"),
-					Str(clusteredKeyword),
-				)
+				}
+				if w.CreateTable_WithClusterHint {
+					fns = append(fns, Str(clusteredKeyword))
+				}
+				return And(fns...)
 			})
 			return Or(
 				idxDef.SetW(1),

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -1,6 +1,7 @@
 package sqlgen
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
@@ -1046,7 +1047,10 @@ func RunInteractTest(ctx context.Context, db1, db2 *sql.DB, state *State, sql st
 	}
 	h1, h2 := rs1.OrderedDigest(resultset.DigestOptions{}), rs2.OrderedDigest(resultset.DigestOptions{})
 	if h1 != h2 {
-		return fmt.Errorf("result digests mismatch: %s != %s %q", h1, h2, sql)
+		var b1, b2 bytes.Buffer
+		rs1.PrettyPrint(&b1)
+		rs2.PrettyPrint(&b2)
+		return fmt.Errorf("result digests mismatch: %s != %s %q\n%s\n%s", h1, h2, sql, b1.String(), b2.String())
 	}
 	if rs1.IsExecResult() && rs1.ExecResult().RowsAffected != rs2.ExecResult().RowsAffected {
 		return fmt.Errorf("rows affected mismatch: %d != %d %q",


### PR DESCRIPTION
some testcase need compare same sql with different @global.tidb_enable_clustered value.

we should have option to generate SQL without clustered keyword and control clustered behavior by global vars

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap-qe/clustered-index-rand-test/20)
<!-- Reviewable:end -->
