### PR TITLE
support order by and limit

### DIFF
--- a/sqlgen/db_config.go
+++ b/sqlgen/db_config.go
@@ -56,6 +56,7 @@ type Weight struct {
 	Query_Analyze               int
 	Query_Prepare               int
 	Query_HasLimit              int
+	Query_HasOrderby            int
 	Query_INDEX_MERGE           bool
 	SetRowFormat                int
 	SetClustered                int
@@ -106,7 +107,8 @@ var DefaultWeight = Weight{
 	Query_Split:                 1,
 	Query_Analyze:               0,
 	Query_Prepare:               2,
-	Query_HasLimit:              1,
+	Query_HasLimit:              0,
+	Query_HasOrderby:            0,
 	SetClustered:                1,
 	SetRowFormat:                1,
 	AdminCheck:                  1,

--- a/sqlgen/db_printer.go
+++ b/sqlgen/db_printer.go
@@ -182,8 +182,9 @@ func PrintRandomAggFunc(tbl *Table, cols []*Column) string {
 	if arg.canDistinct && rand.Intn(3) == 0 {
 		str += "distinct "
 	}
+	var col *Column
 	for i := 0; i < arg.minArg; i++ {
-		col := cols[rand.Intn(len(cols))]
+		col = cols[rand.Intn(len(cols))]
 		if i > 0 {
 			str += ","
 		}
@@ -192,6 +193,12 @@ func PrintRandomAggFunc(tbl *Table, cols []*Column) string {
 	if arg.name == "approx_percentile" {
 		str += ", " + strconv.FormatInt(rand.Int63n(100), 10)
 	}
+
+	// make result of group_concat not affected by ordering of data
+	if arg.name == "group_concat" {
+		str += " order by " + col.Name
+	}
+
 	str += ") aggCol"
 	return str
 }

--- a/sqlgen/db_printer.go
+++ b/sqlgen/db_printer.go
@@ -236,16 +236,13 @@ func PrintRandomWindowFunc(tbl *Table) string {
 
 func PrintRandomWindow(tbl *Table) string {
 	hasPartition := rand.Intn(2) == 0
-	hasOrderBy := rand.Intn(2) == 0
 	hasFrame := rand.Intn(2) == 0
 	var partitionClause, orderByClause, frameClause string
 	if hasPartition {
 		partitionClause = fmt.Sprintf("partition by %s", tbl.GetRandColumn().Name)
 	}
-	if hasOrderBy {
-		orderByClause = fmt.Sprintf("order by %s", tbl.GetRandColumn().Name)
-	}
-	if hasFrame && hasOrderBy {
+	orderByClause = fmt.Sprintf("order by %s", PrintColumnNamesWithoutPar(tbl.Columns, ""))
+	if hasFrame {
 		frames := []string{
 			"current row",
 			fmt.Sprintf("%d preceding", rand.Intn(5)),

--- a/sqlgen/db_retriever.go
+++ b/sqlgen/db_retriever.go
@@ -257,6 +257,15 @@ func (t *Table) Clone(tblIDFn, colIDFn, idxIDFn func() int) *Table {
 	return newTable
 }
 
+func (t *Table) GetAllColFns() []Fn {
+	result := make([]Fn, 0, len(t.Columns))
+	cols := t.cloneColumns()
+	for _, col := range cols {
+		result = append(result, Str(col.Name))
+	}
+	return result
+}
+
 func (t *Table) GetRandColumns() []*Column {
 	if RandomBool() {
 		// insert into t values (...)

--- a/sqlgen/db_retriever.go
+++ b/sqlgen/db_retriever.go
@@ -257,15 +257,6 @@ func (t *Table) Clone(tblIDFn, colIDFn, idxIDFn func() int) *Table {
 	return newTable
 }
 
-func (t *Table) GetAllColFns() []Fn {
-	result := make([]Fn, 0, len(t.Columns))
-	cols := t.cloneColumns()
-	for _, col := range cols {
-		result = append(result, Str(col.Name))
-	}
-	return result
-}
-
 func (t *Table) GetRandColumns() []*Column {
 	if RandomBool() {
 		// insert into t values (...)

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -344,7 +344,7 @@ func newGenerator(state *State) func() string {
 				OptIf(w.Query_HasOrderby > 0,
 					And(
 						Str("order by"),
-						Join(Str(","), tbl.GetAllColFns()...),
+						Str(PrintColumnNamesWithoutPar(tbl.Columns, "")),
 					),
 				),
 				OptIf(w.Query_HasLimit > 0,
@@ -449,7 +449,7 @@ func newGenerator(state *State) func() string {
 					OptIf(w.Query_HasOrderby > 0,
 						And(
 							Str("order by"),
-							Join(Str(","), tbl.GetAllColFns()...),
+							Str(PrintColumnNamesWithoutPar(tbl.Columns, "")),
 						),
 					),
 					OptIf(w.Query_HasLimit > 0,
@@ -470,7 +470,7 @@ func newGenerator(state *State) func() string {
 				OptIf(w.Query_HasOrderby > 0,
 					And(
 						Str("order by"),
-						Join(Str(","), tbl.GetAllColFns()...),
+						Str(PrintColumnNamesWithoutPar(tbl.Columns, "")),
 					),
 				),
 				OptIf(w.Query_HasLimit > 0,
@@ -503,7 +503,7 @@ func newGenerator(state *State) func() string {
 				OptIf(w.Query_HasOrderby > 0,
 					And(
 						Str("order by"),
-						Join(Str(","), tbl.GetAllColFns()...),
+						Str(PrintColumnNamesWithoutPar(tbl.Columns, "")),
 					),
 				),
 				OptIf(w.Query_HasLimit > 0,
@@ -987,7 +987,7 @@ func newGenerator(state *State) func() string {
 				OptIf(w.Query_HasOrderby > 0,
 					And(
 						Str("order by"),
-						Join(Str(","), tbl1.GetAllColFns()...),
+						Str(PrintColumnNamesWithoutPar(tbl1.Columns, "")),
 					),
 				),
 				OptIf(w.Query_HasLimit > 0,
@@ -1028,7 +1028,9 @@ func newGenerator(state *State) func() string {
 				OptIf(w.Query_HasOrderby > 0,
 					And(
 						Str("order by"),
-						Join(Str(","), append(tbl1.GetAllColFns(), tbl2.GetAllColFns()...)...),
+						Str(PrintColumnNamesWithoutPar(tbl1.Columns, "")),
+						Str(","),
+						Str(PrintColumnNamesWithoutPar(tbl2.Columns, "")),
 					),
 				),
 				OptIf(w.Query_HasLimit > 0,
@@ -1071,7 +1073,9 @@ func newGenerator(state *State) func() string {
 				OptIf(w.Query_HasOrderby > 0,
 					And(
 						Str("order by"),
-						Join(Str(","), append(tbl1.GetAllColFns(), tbl2.GetAllColFns()...)...),
+						Str(PrintColumnNamesWithoutPar(tbl1.Columns, "")),
+						Str(","),
+						Str(PrintColumnNamesWithoutPar(tbl2.Columns, "")),
 					),
 				),
 				OptIf(w.Query_HasLimit > 0,

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -509,8 +509,7 @@ func newGenerator(state *State) func() string {
 				Str("("), windowSelect, forUpdateOpt, Str(")"),
 				OptIf(w.Query_HasOrderby > 0,
 					And(
-						Str("order by"),
-						Str(PrintColumnNamesWithoutPar(tbl.Columns, "")),
+						Str("order by 1"),
 					),
 				),
 				OptIf(w.Query_HasLimit > 0,

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -1202,6 +1202,8 @@ func RunInteractTest(ctx context.Context, db1, db2 *sql.DB, state *State, sql st
 	return runInteractTest(ctx, db1, db2, state, sql, true)
 }
 
+// RunInteractTestNoSort is similar to RunInteractTest, but RunInteractTestNoSort doesn't sort the query results
+// before compare them. It'll be useful to run tests for SQLs with "order by" clause.
 func RunInteractTestNoSort(ctx context.Context, db1, db2 *sql.DB, state *State, sql string) error {
 	return runInteractTest(ctx, db1, db2, state, sql, false)
 }

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -477,7 +477,7 @@ func newGenerator(state *State) func() string {
 				OptIf(w.Query_HasOrderby > 0,
 					And(
 						Str("order by"),
-						Str(PrintColumnNamesWithoutPar(tbl.Columns, "")),
+						Str(PrintColumnNamesWithoutPar(cols, "")),
 					),
 				),
 				OptIf(w.Query_HasLimit > 0,

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -455,6 +455,8 @@ func newGenerator(state *State) func() string {
 						And(
 							Str("order by"),
 							Str(PrintColumnNamesWithoutPar(tbl.Columns, "")),
+							Str(", "),
+							Str(windowFunc+" over w"),
 						),
 					),
 					OptIf(w.Query_HasLimit > 0,

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -446,6 +446,18 @@ func newGenerator(state *State) func() string {
 					Str(tbl.Name),
 					Str("window w as"),
 					Str(window),
+					OptIf(w.Query_HasOrderby > 0,
+						And(
+							Str("order by"),
+							Join(Str(","), tbl.GetAllColFns()...),
+						),
+					),
+					OptIf(w.Query_HasLimit > 0,
+						And(
+							Str("limit"),
+							Str(RandomNum(1, 1000)),
+						),
+					),
 				).SetW(w.Query_Window),
 			)
 		})
@@ -488,6 +500,18 @@ func newGenerator(state *State) func() string {
 				Str("("), windowSelect, forUpdateOpt, Str(")"),
 				union,
 				Str("("), windowSelect, forUpdateOpt, Str(")"),
+				OptIf(w.Query_HasOrderby > 0,
+					And(
+						Str("order by"),
+						Join(Str(","), tbl.GetAllColFns()...),
+					),
+				),
+				OptIf(w.Query_HasLimit > 0,
+					And(
+						Str("limit"),
+						Str(RandomNum(1, 1000)),
+					),
+				),
 			),
 			If(len(state.tables) > 1,
 				multiTableQuery,


### PR DESCRIPTION
add options and generate SQLs with `order by` and `limit`
add method `RunInteractTestNoSort` to run a/b tests without sorting query result