### PR TITLE
sqlgen: support exclude some types when generate schema

### DIFF
--- a/sqlgen/db_config.go
+++ b/sqlgen/db_config.go
@@ -45,6 +45,7 @@ type Weight struct {
 	CreateTable_MustPrefixIndex bool
 	CreateTable_MustStrCol      bool
 	CreateTable_MustIntCol      bool
+	CreateTable_IgnoredTypeCols []ColumnType
 	Query                       int
 	Query_DML                   int
 	Query_Select                int

--- a/sqlgen/db_generator.go
+++ b/sqlgen/db_generator.go
@@ -18,9 +18,22 @@ func GenNewTable(id int) *Table {
 	return newTbl
 }
 
+func randColumnType(w *Weight) (ctp ColumnType) {
+retry:
+	for {
+		ctp = ColumnType(rand.Intn(int(ColumnTypeMax)))
+		for _, ignoredType := range w.CreateTable_IgnoredTypeCols {
+			if ignoredType == ctp {
+				continue retry
+			}
+		}
+		return ctp
+	}
+}
+
 func GenNewColumn(id int, w *Weight) *Column {
 	col := &Column{Id: id, Name: fmt.Sprintf("col_%d", id)}
-	col.Tp = ColumnType(rand.Intn(int(ColumnTypeMax)))
+	col.Tp = randColumnType(w)
 	// collate is only used if the type is string.
 	col.collate = CollationType(rand.Intn(int(CollationTypeMax)-1) + 1)
 	if w.CreateTable_MustStrCol {


### PR DESCRIPTION
currently, some column types handling logic in executors has some known but hard to fix the problem, we may need to control  generated column types to stable run daily test