### PR TITLE
sqlgen: support forbid multiple update/delete

### DIFF
--- a/sqlgen/db_config.go
+++ b/sqlgen/db_config.go
@@ -5,22 +5,23 @@ import "math/rand"
 type ConfigKeyType int64
 
 const (
-	ConfigKeyNone                     ConfigKeyType = iota
-	ConfigKeyProbabilityIndexPrefix                 // value example: 50*Percent
-	ConfigKeyProbabilityTiFlashTable                // value example: 50*Percent
-	ConfigKeyUnitTiFlashQueryHint                   // value example: struct{}{}
-	ConfigKeyUnitFirstColumnIndexable               // value example: struct{}{}
-	ConfigKeyUnitLimitIndexKeyLength                // value example: struct{}{}
-	ConfigKeyUnitPKNeedClusteredHint                // value example: struct{}{}
-	ConfigKeyUnitIndexMergeHint                     // value example: struct{}{}
-	ConfigKeyUnitIndexMergePredicate                // value example: struct{}{}
-	ConfigKeyUnitNonStrictTransTable                // value example: struct{}{}
-	ConfigKeyUnitAvoidAlterPKColumn                 // value example: struct{}{}
-	ConfigKeyUnitAvoidDropPrimaryKey                // value example: struct{}{}
-	ConfigKeyEnumLimitOrderBy                       // value should be "none", "order-by", "limit-order-by"
-	ConfigKeyArrayAllowColumnTypes                  // value example: ColumnTypes{ColumnTypeInt, ColumnTypeTinyInt}
-	ConfigKeyIntMaxTableCount                       // value example: 10
-	ConfigKeyCTEValidSQLPercent                     // value example: [0,100]
+	ConfigKeyNone                        ConfigKeyType = iota
+	ConfigKeyProbabilityIndexPrefix                    // value example: 50*Percent
+	ConfigKeyProbabilityTiFlashTable                   // value example: 50*Percent
+	ConfigKeyUnitTiFlashQueryHint                      // value example: struct{}{}
+	ConfigKeyUnitFirstColumnIndexable                  // value example: struct{}{}
+	ConfigKeyUnitLimitIndexKeyLength                   // value example: struct{}{}
+	ConfigKeyUnitPKNeedClusteredHint                   // value example: struct{}{}
+	ConfigKeyUnitIndexMergeHint                        // value example: struct{}{}
+	ConfigKeyUnitIndexMergePredicate                   // value example: struct{}{}
+	ConfigKeyUnitNonStrictTransTable                   // value example: struct{}{}
+	ConfigKeyUnitAvoidAlterPKColumn                    // value example: struct{}{}
+	ConfigKeyUnitAvoidDropPrimaryKey                   // value example: struct{}{}
+	ConfigKeyEnumLimitOrderBy                          // value should be "none", "order-by", "limit-order-by"
+	ConfigKeyArrayAllowColumnTypes                     // value example: ColumnTypes{ColumnTypeInt, ColumnTypeTinyInt}
+	ConfigKeyIntMaxTableCount                          // value example: 10
+	ConfigKeyCTEValidSQLPercent                        // value example: [0,100]
+	ConfigKeyProbabilityUpdateDeleteJoin               // value example: 50*Percent
 )
 
 const (

--- a/sqlgen/db_retriever.go
+++ b/sqlgen/db_retriever.go
@@ -37,7 +37,11 @@ func (s *State) GetRandTableOrCTEs() Tables {
 	tbls = tbls[:mathutil.Min(10, len(tbls))]
 	n := len(tbls)
 	x := rand.Intn(n * n * (n + 1) * (n + 1) / 4)
-	return tbls[:n-(int(math.Sqrt(2*math.Sqrt(float64(x))+0.25)-0.5))]
+	tbls = tbls[:n-(int(math.Sqrt(2*math.Sqrt(float64(x))+0.25)-0.5))]
+	if len(tbls) > 1 && !s.Roll(ConfigKeyProbabilityUpdateDeleteJoin, 100*Percent) {
+		tbls = tbls[:1]
+	}
+	return tbls
 }
 
 func (s *State) IncCTEDeep() {


### PR DESCRIPTION
support ConfigKeyProbabilityUpdateDeleteJoin to change multi update/delete percent

background: now it often generate  CARTESIAN JOIN Update  like:

```
create table tbl_0 ( col_0 mediumint unsigned not null , col_1 varchar(180) collate utf8mb4_general_ci not null , col_2 decimal(26,21) default 0.4 , col_3 date default '2022-07-31' , col_4 time default '03:31:04.00' not null , col_5 text(221) collate utf8_unicode_ci not null , col_6 set('Alice','Bob','Charlie','David') not null , col_7 tinyint unsigned not null , col_8 boolean not null , col_9 char(244) collate utf8_unicode_ci not null , primary key idx_0 ( col_4,col_8,col_2,col_1,col_3,col_9,col_6,col_7 ) , unique key idx_1 ( col_4,col_5(4),col_6,col_3,col_0,col_7 ) , unique key idx_2 ( col_5(4),col_8,col_7,col_6 ) ) collate utf8_bin;
insert into tbl_0 values ( 494158,'GBrJYjHiQYE',85.781,'1997-03-08','13:53:43.00','','Charlie',195,1,'mZL' );
insert into tbl_0 values ( 6978055,'iOmrajUrSlXl',0.7,'2012-06-30','15:40:40.00','ohbdrxAScU','David',19,1,'i' );
insert into tbl_0 values ( 15513358,'GnlwkqNTYvWqmYaCd',239.15,'2007-12-26','22:02:30.00','LnGLBgIla','Charlie',163,0,'jCfEeGzVkNyytxGU' );
insert into tbl_0 values ( 8217385,'BnHKhaExAYcjVGyUyV',7741.5061,'1979-06-21','13:37:27.00','W','David',28,0,'btSOpvYdwSbO' );
insert into tbl_0 values ( 12277580,'sjaxkH',50.7479,'1999-02-06','16:18:34.00','QofX','Bob',68,1,'blmHmlislwRxEsx' );
insert into tbl_0 values ( 12342007,'gbNxHhErKAQfD',39.9,'2008-10-24','07:09:33.00','CIaAHUMf','Charlie',54,0,'nHCVVosPD' );
insert into tbl_0 values ( 6678054,'OWYTGjIGTGcnsDa',15227.6489,'1979-01-01','19:27:14.00','oibDv','David',169,1,'EhcieFTiGTruldckGFq' );
insert into tbl_0 values ( 155168,'BuWvmHFVDfow',9730.72,'2021-11-30','02:17:51.00','or','Alice',94,1,'rGwkD' );
insert into tbl_0 values ( 10819422,'pjxSgSlmRhdeia',null,null,'03:52:17.00','tESwCCxTvLFLzQd','Bob',103,1,'mYUrgMGxqhJxkkYPNL' );
insert into tbl_0 values ( 8391918,'QfcqwJwgejek',113.7,'1974-07-01','23:27:46.00','GvkCUKktPFlcgVZJ','Charlie',156,1,'TiosWsesqX' );
create table tbl_7 ( col_59 blob(101) collate binary not null , col_60 blob(194) collate binary , col_61 binary(111) collate binary , col_62 varbinary(433) collate binary default 'xAsJjE' not null , col_63 text(76) collate utf8_bin not null , col_64 blob(274) collate binary , col_65 char(92) collate utf8_bin , col_66 enum('Alice','Bob','Charlie','David') default 'David' ) collate utf8mb4_bin ;
insert  into tbl_7  values ( 'MZZc','DGlqgCEz','esilmfq','dBqrV','wueUZQSnUJLRnxo','',null,'Bob' ) , ( 'IAdjlms','OvAqcKclpPCjc','tFrywW','lodMbZitfPnTWYVt','TsRfRBovwMxOQDkw','RNNSuIpSiFsMfrAEixy','vfafTOCllqb','Bob' ) , ( 'iWp','qPprFilycX','rwlRkIRgjmSlyCOnH','ZOy','EqulcIgjk','nTmIfyTwBwZnp','nawKpCdRvHVBvOT','Alice' ) , ( 'NQXOsazLINB','rIWspQ','iWXaDghaAdJf','upLdBsOyvfQF','VBZFWCFtBaT','vQjuoGmKsYWKXU','EoVfAPjonWfbma','Alice' ) , ( 'dArYlXnUsWnuTNsNkZf','EWoJHsWcXJKwBzmPJ','ELWcCjudxkVIhHfSa','QMBHTtraygAvOdgXF','jcVrDwx','nec','pT','Bob' ) , ( 'hkQcxOWLpZc','HapSLLJENubbEcdWQ','','MNCqZeaZfIoPR','cfGdkwzGXh','DIaHxxvKD','sazVKQQFHZbxsdKA','David' ) on duplicate key update col_63 = 'HGwtIGbkQoNYEOaf', col_59 = 'hfIucGWgf', col_61 = 'LjZkQ', col_66 = 'Charlie', col_62 = 'YhxHXusPo';
update tbl_0,tbl_7 set tbl_7 . col_63 = 'BGEbU' , tbl_7 . col_59 = tbl_0 . col_6 , tbl_7 . col_65 = tbl_0 . col_9 where not( tbl_7.col_66 between 'David' and 'David' ) and not( IsNull( tbl_7.col_64 ) ) and tbl_7.col_63 not in ( 'bTRyMyKGshF' ) and not( tbl_7.col_59 in ( 'yCUgmNKVxPYpSsGan' , 'c' , 'fobKEfsgunwkzJ' , 'aDoiiNHyqAMn' , 'shKotcMucqTLZddfqwF' ) ) ;
```

the update result is different if join result has different order...

clustered vs nonclustered often has those order problem, the behavior is desirable but for daily regression test is better generate stale result sql ..(for simple :)