### PR TITLE
sqlgen: stable agg test result

### DIFF
--- a/sqlgen/db_config.go
+++ b/sqlgen/db_config.go
@@ -17,6 +17,7 @@ const (
 	ConfigKeyUnitNonStrictTransTable                // value example: struct{}{}
 	ConfigKeyUnitAvoidAlterPKColumn                 // value example: struct{}{}
 	ConfigKeyUnitAvoidDropPrimaryKey                // value example: struct{}{}
+	ConfigKeyStableOrderBy                          // value example: struct{}{}
 	ConfigKeyEnumLimitOrderBy                       // value should be "none", "order-by", "limit-order-by"
 	ConfigKeyArrayAllowColumnTypes                  // value example: ColumnTypes{ColumnTypeInt, ColumnTypeTinyInt}
 	ConfigKeyIntMaxTableCount                       // value example: 10

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -339,7 +339,7 @@ var AggregationSelect = NewFn(func(state *State) Fn {
 		If(len(pkCols) == 0, Strs("order by", PrintColumnNamesWithoutPar(tbl.Columns, ""))),
 		Str(") ordered_tbl"),
 		GroupByColumnsOpt,
-		Opt(Str("order by aggCol")),
+		Str("order by aggCol"),
 	}
 	if !state.ExistsConfig(ConfigKeyStableOrderBy) {
 		fns = append(fns, Opt(Strs("limit", RandomNum(1, 1000))))

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -307,6 +307,9 @@ var CommonSelect = NewFn(func(state *State) Fn {
 	cols := tbl.Columns.GetRandNColumns(state.Search(ScopeKeyCurrentSelectedColNum).ToInt())
 	state.Store(ScopeKeyCurrentTables, Tables{tbl})
 	orderByCols := tbl.Columns.GetRandColumnsNonEmpty()
+	if state.ExistsConfig(ConfigKeyStableOrderBy) {
+		orderByCols = tbl.Columns
+	}
 	state.Store(ScopeKeyCurrentOrderByColumns, NewTableColumnPairs1ToN(tbl, orderByCols))
 	if state.Exists(ScopeKeyCurrentPrepare) {
 		paramCols := SwapOutParameterizedColumns(cols)
@@ -327,7 +330,7 @@ var AggregationSelect = NewFn(func(state *State) Fn {
 	tbl := state.GetRandTable()
 	state.Store(ScopeKeyCurrentTables, Tables{tbl})
 	pkCols := tbl.GetUniqueKeyColumns()
-	return And(
+	fns := []Fn{
 		Str("select"), HintAggToCop, AggFunction, Str("aggCol"),
 		Str("from"),
 		Str("(select"), HintTiFlash, HintIndexMerge, Str("*"),
@@ -337,9 +340,12 @@ var AggregationSelect = NewFn(func(state *State) Fn {
 		Str(") ordered_tbl"),
 		GroupByColumnsOpt,
 		Opt(Str("order by aggCol")),
-		Opt(Strs("limit", RandomNum(1, 1000))),
-		ForUpdateOpt,
-	)
+	}
+	if !state.ExistsConfig(ConfigKeyStableOrderBy) {
+		fns = append(fns, Opt(Strs("limit", RandomNum(1, 1000))))
+	}
+	fns = append(fns, ForUpdateOpt)
+	return And(fns...)
 })
 
 var GroupByColumnsOpt = NewFn(func(state *State) Fn {
@@ -609,7 +615,11 @@ var CommonUpdate = NewFn(func(state *State) Fn {
 	tbls := state.GetRandTableOrCTEs()
 	state.Store(ScopeKeyCurrentTables, tbls)
 	tbl := tbls[rand.Intn(len(tbls))]
-	state.Store(ScopeKeyCurrentOrderByColumns, NewTableColumnPairs1ToN(tbl, tbl.Columns.GetRandColumnsNonEmpty()))
+	cols := tbl.Columns.GetRandColumnsNonEmpty()
+	if state.ExistsConfig(ConfigKeyStableOrderBy) {
+		cols = tbl.Columns
+	}
+	state.Store(ScopeKeyCurrentOrderByColumns, NewTableColumnPairs1ToN(tbl, cols))
 	return And(
 		Str("update"),
 		Str(PrintTableNames(tbls)),
@@ -640,7 +650,11 @@ var CommonDelete = NewFn(func(state *State) Fn {
 		whereCol = whereTbl.GetRandColumn()
 	}
 	orderByTbl := tbls[rand.Intn(len(tbls))]
-	state.Store(ScopeKeyCurrentOrderByColumns, NewTableColumnPairs1ToN(orderByTbl, orderByTbl.Columns.GetRandColumnsNonEmpty()))
+	cols := orderByTbl.Columns.GetRandColumnsNonEmpty()
+	if state.ExistsConfig(ConfigKeyStableOrderBy) {
+		cols = orderByTbl.Columns
+	}
+	state.Store(ScopeKeyCurrentOrderByColumns, NewTableColumnPairs1ToN(orderByTbl, cols))
 
 	var randRowVal = NewFn(func(state *State) Fn {
 		return Str(whereCol.RandomValue())

--- a/sqlgen/start.go
+++ b/sqlgen/start.go
@@ -333,6 +333,7 @@ var AggregationSelect = NewFn(func(state *State) Fn {
 		Str("(select"), HintTiFlash, HintIndexMerge, Str("*"),
 		Str("from"), Str(tbl.Name), Str("where"), Predicates,
 		If(len(pkCols) != 0, Strs("order by", PrintColumnNamesWithoutPar(pkCols, ""))),
+		If(len(pkCols) == 0, Strs("order by", PrintColumnNamesWithoutPar(tbl.Columns, ""))),
 		Str(") ordered_tbl"),
 		GroupByColumnsOpt,
 		Opt(Str("order by aggCol")),


### PR DESCRIPTION
current it maybe generate sql like:

```
(SELECT /*+   */ Var_pop(DISTINCT col_377) aggCol
 FROM   (SELECT *
         FROM   tbl_56
         WHERE  NOT( tbl_56.col_377 IN ( 3431823, 7014311, 1856044 ) )
                 OR NOT( tbl_56.col_380 >= 222275 )) ordered_tbl
 ORDER  BY aggcol
 LIMIT  122)
UNION ALL
(SELECT /*+  stream_agg() */ Group_concat(DISTINCT col_92 ORDER BY col_92)
                             aggCol
 FROM   (SELECT *
         FROM   tbl_12
         WHERE  tbl_12.col_92 BETWEEN -74 AND 76
         ORDER  BY col_94,
                   col_90,
                   col_92,
                   col_91) ordered_tbl
 GROUP  BY col_93,
           col_91,
           col_90,
           col_92,
           col_94
 ORDER  BY aggcol
 LIMIT  273
 FOR UPDATE)
ORDER  BY aggcol
LIMIT
202 
```

which `ordered_tbl` isn't ordered, so `var_pop` maybe different due to order(i.e.: 12521690508717.893 vs 12521690508717.89)

force order by maybe better choose to avoid false-failure in daily test